### PR TITLE
Exclude inactive members/consortium organizations from query to fix counts

### DIFF
--- a/plugins/datacite-custom-shortcodes/js/members.js
+++ b/plugins/datacite-custom-shortcodes/js/members.js
@@ -274,7 +274,7 @@ function getMembers(member_type) {
 function getConsortiumMembers(member_id) {
   var xmlhttp = new XMLHttpRequest();
   var url =
-    "https://api.datacite.org/providers?consortium-id={{member_id}}&page[size]=400".replace("{{member_id}}", member_id);
+    "https://api.datacite.org/providers?query=is_active:%5Cu0001&consortium-id={{member_id}}&page[size]=400".replace("{{member_id}}", member_id);
 
   xmlhttp.onreadystatechange = function () {
     if (xmlhttp.readyState == 4 && xmlhttp.status == 200) {

--- a/plugins/datacite-custom-shortcodes/js/members.js
+++ b/plugins/datacite-custom-shortcodes/js/members.js
@@ -260,7 +260,7 @@ function getCountryName(countryCode) {
 function getMembers(member_type) {
     var xmlhttp = new XMLHttpRequest();
     var url =
-      "https://api.datacite.org/providers?query=-id:txvt&member-type={{member_type}}&exclude-registration-agencies=true&page[size]=400".replace("{{member_type}}", member_type);
+      "https://api.datacite.org/providers?query=-id:txvt%20AND%20is_active:%5Cu0001&member-type={{member_type}}&exclude-registration-agencies=true&page[size]=400".replace("{{member_type}}", member_type);
 
     xmlhttp.onreadystatechange = function () {
       if (xmlhttp.readyState == 4 && xmlhttp.status == 200) {


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

The current totals for each type of member include both active and inactive members, although these were excluded from the list. This resulted in a discrepancy between the number of members displayed (e.g., 69 consortia) and the number of members in the list (e.g., 66 consortia). See this Slack thread for context: https://datacite.slack.com/archives/C0CFZNZFE/p1765859289154879

## Approach
<!--- _How does this change address the problem?_ -->

Update the queries to filter for is_active=true. This is encoded as `is_active=\u0001`.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->
I'm not set up with Wordpress to test this locally. Therefore, this should be tested on staging to make sure it doesn't break anything before merging into production. 

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
